### PR TITLE
Add --rm flag in Docker run examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,5 +63,5 @@ RUN apt-get autoclean -y && \
 
 ###
 ### Build this file: `docker build -t pwntools .`
-### Run (iTerm2): `docker run -it -v /tmp/data:/tmp/data --privileged --name pwntools --hostname pwntools pwntools tmux -CC`
+### Run (iTerm2): `docker run -it --rm -v /tmp/data:/tmp/data --privileged --name pwntools --hostname pwntools pwntools tmux -CC`
 ###

--- a/README.md
+++ b/README.md
@@ -25,5 +25,5 @@ For convenience it also contains:
 
 ### Run
 
-- OSX (iTerm2): `NAME=pwntools; docker run -it -v /tmp/data:/tmp/data --privileged --name ${NAME} --hostname ${NAME} frankspierings/pwntools tmux -CC`
-- Linux: `NAME=pwntools; docker run -it -v /tmp/data:/tmp/data --privileged --name ${NAME} --hostname ${NAME} frankspierings/pwntools /bin/bash`
+- OSX (iTerm2): `NAME=pwntools; docker run -it --rm -v /tmp/data:/tmp/data --privileged --name ${NAME} --hostname ${NAME} frankspierings/pwntools tmux -CC`
+- Linux: `NAME=pwntools; docker run -it --rm -v /tmp/data:/tmp/data --privileged --name ${NAME} --hostname ${NAME} frankspierings/pwntools /bin/bash`


### PR DESCRIPTION
Add `--rm` flag in Docker run examples. The `--rm` flag automatically removes the container when it exits.